### PR TITLE
Refine layout styling and theme toggling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -386,6 +386,11 @@ export default function B2BResellerMVP() {
   const [isLanding, setIsLanding] = useState(true);
   const [theme, setTheme] = useState("dark");
 
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
   // Sanity checks
   useEffect(() => {
     console.assert(typeof AccordionUI === "function", "[SelfTest] AccordionUI should be defined");

--- a/src/index.css
+++ b/src/index.css
@@ -3,70 +3,53 @@
 @tailwind utilities;
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #0f172a;
+  background-color: #f8fafc;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html.dark {
+  color: #e2e8f0;
+  background-color: #020617;
+  color-scheme: dark;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: radial-gradient(circle at 0% -20%, rgba(14, 116, 144, 0.12), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(59, 130, 246, 0.08), transparent 40%),
+    #f8fafc;
+  color: inherit;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+html.dark body {
+  background: radial-gradient(circle at 0% -20%, rgba(14, 165, 233, 0.18), transparent 55%),
+    radial-gradient(circle at 100% 0%, rgba(99, 102, 241, 0.12), transparent 45%),
+    #020617;
+  color: inherit;
+}
+
+#root {
+  width: 100%;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- replace the default Vite boilerplate CSS with full-width layout scaffolding, modern typography, and light/dark gradient backgrounds so the page renders cleanly
- switch Tailwind to class-based dark mode and sync the React theme toggle with the `<html>` element to ensure dark styles activate consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bf486e94832c845f0da8a4d7cb5b